### PR TITLE
feat: emit key clan events

### DIFF
--- a/src/main/java/cjs/DF_Plugin/events/end/EndEventManager.java
+++ b/src/main/java/cjs/DF_Plugin/events/end/EndEventManager.java
@@ -17,6 +17,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitTask;
+import cjs.DF_Plugin.EmitHelper;
 
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
@@ -124,6 +125,7 @@ public class EndEventManager {
 
         if (broadcast) {
             Bukkit.broadcastMessage("§5[엔드 이벤트] §d엔더 드래곤의 포효가 들려옵니다! 엔드 포탈이 활성화되었습니다!");
+            EmitHelper.endPortalOpened();
             // 모든 플레이어에게 엔드 포탈 활성화 소리를 재생합니다.
             for (Player player : Bukkit.getOnlinePlayers()) {
                 player.playSound(player.getLocation(), Sound.BLOCK_END_PORTAL_SPAWN, 1.0f, 1.0f);
@@ -149,6 +151,7 @@ public class EndEventManager {
 
         if (broadcast) {
             Bukkit.broadcastMessage("§5[엔드 이벤트] §d공허의 기운이 꿈틀거립니다... " + minutes + "분 뒤 엔드 포탈이 열립니다!");
+            EmitHelper.endPortalCountdown(minutes);
         }
 
         openTask = Bukkit.getScheduler().runTaskLater(plugin, () -> openEnd(true), minutes * 60 * 20L);
@@ -177,6 +180,7 @@ public class EndEventManager {
         // 드래곤이 죽으면 붕괴 상태로 전환됩니다. isEndOpen은 false가 되어 더 이상 진입할 수 없습니다.
         this.currentState = State.COLLAPSING;
         Bukkit.broadcastMessage("§5[엔드 이벤트] §c엔더 드래곤이 쓰러져 엔드 포탈이 닫혔습니다!");
+        EmitHelper.enderDragonDefeated();
 
         World endWorld = Bukkit.getWorld("world_the_end");
         if (endWorld != null) {
@@ -188,6 +192,7 @@ public class EndEventManager {
 
         long delayMinutes = plugin.getGameConfigManager().getConfig().getLong("end-event.collapse-delay-minutes", 10);
         Bukkit.broadcastMessage("§5[엔드 이벤트] §c엔드 월드가 " + delayMinutes + "분 뒤 붕괴를 시작합니다! 서둘러 탈출하세요!");
+        EmitHelper.endWorldCollapseSoon(delayMinutes);
 
         this.collapseFinishTime = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(delayMinutes);
         saveState();

--- a/src/main/java/cjs/DF_Plugin/events/rift/RiftManager.java
+++ b/src/main/java/cjs/DF_Plugin/events/rift/RiftManager.java
@@ -3,6 +3,7 @@ package cjs.DF_Plugin.events.rift;
 import cjs.DF_Plugin.DF_Main;
 import cjs.DF_Plugin.pylon.clan.Clan;
 import cjs.DF_Plugin.upgrade.UpgradeManager;
+import cjs.DF_Plugin.EmitHelper;
 import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
@@ -145,7 +146,8 @@ public class RiftManager {
             saveAltarData(); // 제단 블록 구조 저장
 
             Bukkit.broadcastMessage("§d[차원의 균열] §f차원의 어딘가가 불안정합니다.");
-
+            EmitHelper.riftUnstable();
+            
             // 모든 가문 창고에 균열 위치를 가리키는 나침반을 배치합니다.
             placeRiftCompassInStorages();
 
@@ -321,6 +323,7 @@ public class RiftManager {
                         altarStateBossBar.setTitle("§c이계의 알이 도착했습니다");
                         altarStateBossBar.setColor(BarColor.RED);
                         Bukkit.broadcastMessage("§d[차원의 균열] §f균열에서 강력한 기운이 감지됩니다!");
+                        EmitHelper.riftStrongEnergy();
                         Bukkit.getOnlinePlayers().forEach(p -> p.playSound(p.getLocation(), Sound.ENTITY_WITHER_SPAWN, 1.0f, 0.7f));
                     } else {
                         // Update countdown progress
@@ -398,6 +401,7 @@ public class RiftManager {
         cleanupBossBar();
 
         Bukkit.broadcastMessage("§d[차원의 균열] §f차원의 균열이 닫힙니다.");
+        EmitHelper.riftClosed();
         Bukkit.getOnlinePlayers().forEach(p -> p.playSound(p.getLocation(), Sound.ENTITY_WITHER_DEATH, 1.0f, 0.6f));
 
         // 신호기만 파괴

--- a/src/main/java/cjs/DF_Plugin/pylon/beacongui/recruit/RecruitGuiManager.java
+++ b/src/main/java/cjs/DF_Plugin/pylon/beacongui/recruit/RecruitGuiManager.java
@@ -9,6 +9,7 @@ import cjs.DF_Plugin.player.stats.StatType;
 import cjs.DF_Plugin.player.stats.StatsManager;
 import cjs.DF_Plugin.pylon.beacongui.BeaconGUIManager;
 import cjs.DF_Plugin.util.PluginUtils;
+import cjs.DF_Plugin.EmitHelper;
 import org.bukkit.*;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.Sound;
@@ -417,6 +418,7 @@ public class RecruitGuiManager implements Listener {
 
         spawnRecruitmentFireworks(recruiter);
         recruiter.sendMessage(PREFIX + "§a" + recruitedPlayer.getName() + "님을 새로운 가문원으로 영입했습니다!");
+        EmitHelper.clanMemberJoined(clan.getName(), recruitedPlayer.getName() != null ? recruitedPlayer.getName() : recruitedPlayer.getUniqueId().toString());
 
         if (recruitedPlayer.isOnline()) {
             Player onlineTarget = recruitedPlayer.getPlayer();

--- a/src/main/java/cjs/DF_Plugin/pylon/beaconinteraction/PylonAreaManager.java
+++ b/src/main/java/cjs/DF_Plugin/pylon/beaconinteraction/PylonAreaManager.java
@@ -5,6 +5,7 @@ import cjs.DF_Plugin.pylon.clan.Clan;
 import cjs.DF_Plugin.pylon.PylonType;
 import cjs.DF_Plugin.events.game.settings.GameConfigManager;
 import cjs.DF_Plugin.util.PluginUtils;
+import cjs.DF_Plugin.EmitHelper;
 import org.bukkit.Particle;
 import org.bukkit.Material;
 import org.bukkit.Location;
@@ -194,6 +195,7 @@ public class PylonAreaManager {
                         if (!previouslyKnownIntruders.contains(player.getUniqueId())) {
                             String warningMessage = PluginUtils.colorize("&c[경고] &f외부인이 파일런 영역에 접근했습니다!");
                             clan.broadcastMessage(warningMessage);
+                            EmitHelper.clanIntrusion(clan.getName(), plugin.getClanManager().getClanByPlayer(player.getUniqueId()) != null ? plugin.getClanManager().getClanByPlayer(player.getUniqueId()).getName() : null);
                         }
                     }
                 }

--- a/src/main/java/cjs/DF_Plugin/pylon/beaconinteraction/PylonListener.java
+++ b/src/main/java/cjs/DF_Plugin/pylon/beaconinteraction/PylonListener.java
@@ -6,6 +6,7 @@ import cjs.DF_Plugin.pylon.clan.ClanManager;
 import cjs.DF_Plugin.util.item.PylonItemFactory;
 import cjs.DF_Plugin.pylon.PylonType;
 import cjs.DF_Plugin.util.PluginUtils;
+import cjs.DF_Plugin.EmitHelper;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -189,6 +190,7 @@ public class PylonListener implements Listener {
             clanManager.saveClanData(victimClan);
             attackerClan.broadcastMessage("§a" + victimClan.getFormattedName() + "§a 가문의 보조 파일런을 파괴했습니다!");
             victimClan.broadcastMessage("§c" + attackerClan.getFormattedName() + "§c 가문에 의해 보조 파일런이 파괴되었습니다!");
+            EmitHelper.pylonDestroyed(victimClan.getName(), attackerClan != null ? attackerClan.getName() : null);
 
             new org.bukkit.scheduler.BukkitRunnable() {
                 @Override

--- a/src/main/java/cjs/DF_Plugin/pylon/clan/ClanManager.java
+++ b/src/main/java/cjs/DF_Plugin/pylon/clan/ClanManager.java
@@ -10,6 +10,7 @@ import cjs.DF_Plugin.upgrade.item.UpgradeItems;
 import cjs.DF_Plugin.pylon.PylonType;
 import cjs.DF_Plugin.util.PlayerTagManager;
 import cjs.DF_Plugin.util.PluginUtils;
+import cjs.DF_Plugin.EmitHelper;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
@@ -199,6 +200,7 @@ public class ClanManager {
     public void absorbClan(Clan attacker, Clan defender) {
         // Notify defender's members about absorption
         defender.broadcastMessage(PluginUtils.colorize("&c[전쟁] &f가문이 멸망하여 " + attacker.getFormattedName() + " §f가문에 흡수되었습니다."));
+        EmitHelper.clanAbsorbed(defender.getName(), attacker.getName());
 
         // Announce to the entire server
         String publicMessage = PluginUtils.colorize("&4[전쟁] " + defender.getFormattedName() + " §c가문이 마지막 파일런을 잃고 " + attacker.getFormattedName() + " §c가문에게 흡수되었습니다!");
@@ -597,6 +599,7 @@ public class ClanManager {
                 clan.broadcastMessage(PluginUtils.colorize("&c[선물상자] &f선물상자가 가득 차서 일부 또는 모든 선물을 받지 못했습니다!"));
             } else {
                 clan.broadcastMessage(PluginUtils.colorize("&d[선물상자] &f가문의 선물상자에 새로운 선물이 도착했습니다!"));
+                EmitHelper.giftboxArrived(clan.getName());
             }
         }
 

--- a/src/main/java/cjs/DF_Plugin/upgrade/UpgradeManager.java
+++ b/src/main/java/cjs/DF_Plugin/upgrade/UpgradeManager.java
@@ -20,6 +20,7 @@ import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.scheduler.BukkitRunnable;
 
 import java.util.*;
+import cjs.DF_Plugin.EmitHelper;
 
 public class UpgradeManager {
 
@@ -146,6 +147,7 @@ public class UpgradeManager {
                     .append(Component.text(" 아이템이 강화에 실패하여 파괴되었습니다.", NamedTextColor.GRAY))
                     .build();
             Bukkit.broadcast(broadcastMessage);
+            EmitHelper.upgradeDestroyed(currentLevel, destroyedItem.getType().name());
             item.setAmount(0);
             player.getWorld().playSound(player.getLocation(), Sound.ENTITY_GENERIC_EXPLODE, 0.7f, 1.0f);
             player.getWorld().spawnParticle(Particle.LARGE_SMOKE, player.getLocation().add(0, 1, 0), 40, 0.5, 0.5, 0.5, 0.05);
@@ -408,6 +410,7 @@ public class UpgradeManager {
         if (meta == null || !meta.hasDisplayName()) return;
 
         String legendaryName = meta.getDisplayName();
+        String cleanLegendaryName = ChatColor.stripColor(legendaryName);
         
         // Adventure API를 사용하여 호버 가능한 메시지 생성
         Component hoverableItemName = LegacyComponentSerializer.legacySection().deserialize(legendaryName)
@@ -424,6 +427,7 @@ public class UpgradeManager {
             p.sendMessage(broadcastMessage);
             p.playSound(p.getLocation(), Sound.UI_TOAST_CHALLENGE_COMPLETE, 0.7f, 1.0f);
         }
+        EmitHelper.upgradeLv10Born(cleanLegendaryName);
     }
 
     private boolean hasEnoughStones(Player player, int amount) {


### PR DESCRIPTION
## Summary
- emit clan intrusion detection events
- broadcast auxiliary pylon destruction and clan absorption
- announce upgrade and end/rift event milestones

## Testing
- `./gradlew test` *(fails: cannot find symbol EmitHelper)*

------
https://chatgpt.com/codex/tasks/task_e_68b2838dcafc8333b1a4e76afa743170